### PR TITLE
Add Prometheus and Grafana manifests with NodePort access

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,38 @@
+# Despliegue completo en Kubernetes
+
+Este directorio contiene los manifiestos necesarios para levantar la API de "Socios Tenis", Prometheus y Grafana dentro del mismo namespace (`socios-tenis`). Las configuraciones están pensadas para ambientes de laboratorio/local con `minikube` o `kind`, exponiendo servicios como `NodePort` para que se puedan consumir desde `localhost`.
+
+## Orden sugerido de despliegue
+
+```bash
+kubectl apply -f namespace.yaml
+kubectl apply -f deployment.yaml
+kubectl apply -f service.yaml
+kubectl apply -f prometheus.yaml
+kubectl apply -f grafana.yaml
+```
+
+> Si ya tenías recursos creados, podés relanzarlos con `kubectl apply -f <archivo>` sin borrar el namespace.
+
+## Accesos rápidos
+
+| Servicio      | URL                      | Usuario | Password |
+|---------------|-------------------------|---------|----------|
+| Aplicación    | http://localhost:30080  | -       | -        |
+| Prometheus    | http://localhost:30090  | -       | -        |
+| Grafana       | http://localhost:30300  | admin   | admin    |
+
+> Para Minikube podés usar `minikube service <service-name> -n socios-tenis --url` si preferís evitar los `NodePort` fijados.
+
+## Cómo validar que las métricas llegan
+
+1. Abre Prometheus y revisa el apartado **Status → Targets**. Debe aparecer `socios-tenis` con estado `UP`.
+2. En Grafana ingresa con `admin / admin` y crea un dashboard nuevo agregando un panel con la query `http_requests_total` para confirmar que se recolectan métricas desde la API.
+
+## Limpieza
+
+```bash
+kubectl delete namespace socios-tenis
+```
+
+Esto eliminará todos los recursos desplegados en este ejemplo.

--- a/k8s/grafana.yaml
+++ b/k8s/grafana.yaml
@@ -1,0 +1,90 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasource
+  namespace: socios-tenis
+  labels:
+    app: grafana
+    component: server
+    managed-by: socios-tenis
+    part-of: observability
+  annotations:
+    grafana_datasource: "1"
+data:
+  datasource.yaml: |-
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus-service.socios-tenis.svc.cluster.local:9090
+        isDefault: true
+        editable: false
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana-deployment
+  namespace: socios-tenis
+  labels:
+    app: grafana
+    component: server
+    managed-by: socios-tenis
+    part-of: observability
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+      component: server
+  template:
+    metadata:
+      labels:
+        app: grafana
+        component: server
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana:10.4.2
+          env:
+            - name: GF_SECURITY_ADMIN_USER
+              value: admin
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              value: admin
+            - name: GF_USERS_ALLOW_SIGN_UP
+              value: "false"
+          ports:
+            - name: http
+              containerPort: 3000
+          volumeMounts:
+            - name: grafana-storage
+              mountPath: /var/lib/grafana
+            - name: grafana-datasource
+              mountPath: /etc/grafana/provisioning/datasources
+      volumes:
+        - name: grafana-storage
+          emptyDir: {}
+        - name: grafana-datasource
+          configMap:
+            name: grafana-datasource
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-service
+  namespace: socios-tenis
+  labels:
+    app: grafana
+    component: server
+    managed-by: socios-tenis
+    part-of: observability
+spec:
+  type: NodePort
+  selector:
+    app: grafana
+    component: server
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000
+      nodePort: 30300

--- a/k8s/prometheus.yaml
+++ b/k8s/prometheus.yaml
@@ -1,0 +1,99 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: socios-tenis
+  labels:
+    app: prometheus
+    component: server
+    managed-by: socios-tenis
+    part-of: observability
+  annotations:
+    description: Configuración mínima de Prometheus con scrape directo al servicio de la app
+    kubernetes.io/description: Prometheus scrape config para socios-tenis
+    checksum/config: "1"
+data:
+  prometheus.yml: |-
+    global:
+      scrape_interval: 15s
+    scrape_configs:
+      - job_name: "socios-tenis"
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+          - role: endpoints
+            namespaces:
+              names:
+                - socios-tenis
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_label_app]
+            action: keep
+            regex: socios-tenis
+          - source_labels: [__meta_kubernetes_endpoint_port_name]
+            action: keep
+            regex: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-deployment
+  namespace: socios-tenis
+  labels:
+    app: prometheus
+    component: server
+    managed-by: socios-tenis
+    part-of: observability
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+      component: server
+  template:
+    metadata:
+      labels:
+        app: prometheus
+        component: server
+    spec:
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v2.52.0
+          args:
+            - "--config.file=/etc/prometheus/prometheus.yml"
+            - "--storage.tsdb.path=/prometheus"
+            - "--web.enable-lifecycle"
+          ports:
+            - name: http
+              containerPort: 9090
+          volumeMounts:
+            - name: prometheus-config
+              mountPath: /etc/prometheus
+              readOnly: true
+            - name: prometheus-storage
+              mountPath: /prometheus
+      volumes:
+        - name: prometheus-config
+          configMap:
+            name: prometheus-config
+        - name: prometheus-storage
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-service
+  namespace: socios-tenis
+  labels:
+    app: prometheus
+    component: server
+    managed-by: socios-tenis
+    part-of: observability
+spec:
+  type: NodePort
+  selector:
+    app: prometheus
+    component: server
+  ports:
+    - name: http
+      port: 9090
+      targetPort: 9090
+      nodePort: 30090

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -8,7 +8,8 @@ spec:
   selector:
     app: socios-tenis
   ports:
-    - protocol: TCP
+    - name: http
+      protocol: TCP
       port: 8000
       targetPort: 8000
       nodePort: 30080   # lo fijamos para que siempre sea http://localhost:30080


### PR DESCRIPTION
## Summary
- name service port to align with ServiceMonitor scraping
- add Prometheus deployment, service and config map to scrape the API metrics
- add Grafana deployment, service and datasource plus documentation for applying manifests

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc500f9bf8832c923bb55aefbeb242