### PR TITLE
Document monitoring setup and fix ServiceMonitor wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+# Socios Tenis ID - Guía de despliegue local con métricas
+
+Este proyecto contiene una API en FastAPI que expone métricas Prometheus mediante `prometheus_fastapi_instrumentator`. A continuación se resume cómo construir la imagen, desplegarla en Minikube y habilitar el stack de observabilidad (Prometheus + Grafana) usando `kube-prometheus-stack`.
+
+## Prerrequisitos
+
+- Docker
+- Minikube configurado con el driver Docker (`minikube start --driver=docker`)
+- Kubectl
+- Helm 3
+
+## Paso a paso
+
+1. **Construir y publicar la imagen (opcional si usas DockerHub)**
+   ```bash
+   ./run.sh build-push
+   ```
+
+2. **Iniciar Minikube**
+   ```bash
+   ./run.sh mk-up
+   ```
+
+3. **Desplegar la aplicación**
+   ```bash
+   ./run.sh mk-deploy
+   ```
+   Esto crea el namespace `socios-tenis`, despliega el `Deployment` y expone la API en el puerto `30080` del nodo de Minikube.
+
+4. **Instalar Prometheus y Grafana**
+   ```bash
+   ./run.sh monitoring-up
+   ```
+   Este comando instala/actualiza `kube-prometheus-stack` en el namespace `monitoring`. El `ServiceMonitor` del proyecto está etiquetado con `release: kube-prometheus-stack`, por lo que el operador detectará automáticamente la API y comenzará a recolectar métricas de `/metrics`.
+
+5. **Acceder a la API**
+   ```bash
+   ./run.sh urls
+   ```
+   Esto abre un túnel a través de `minikube service` hacia la API (`http://localhost:30080`).
+
+6. **Acceder a Grafana y Prometheus**
+   - Grafana:
+     ```bash
+     kubectl port-forward svc/kube-prometheus-stack-grafana -n monitoring 3000:80
+     ```
+     Luego abre http://localhost:3000 (usuario `admin`, contraseña obtenida con `kubectl get secret kube-prometheus-stack-grafana -n monitoring -o jsonpath="{.data.admin-password}" | base64 --decode`).
+
+   - Prometheus:
+     ```bash
+     kubectl port-forward svc/kube-prometheus-stack-prometheus -n monitoring 9090:9090
+     ```
+     Visita http://localhost:9090 para consultar las métricas.
+
+7. **Eliminar recursos**
+   ```bash
+   ./run.sh down
+   ./run.sh monitoring-down
+   ```
+
+## Observabilidad
+
+- El `Service` expone el puerto `8000` con el nombre `http`, lo que permite al `ServiceMonitor` encontrar el endpoint de métricas.
+- `prometheus_fastapi_instrumentator` expone `/metrics` automáticamente, por lo que no se requiere configuración adicional.
+
+Con estos pasos deberías poder desplegar la aplicación, habilitar el stack de monitoreo y visualizar las métricas en Grafana/Prometheus.

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -3,12 +3,15 @@ kind: Service
 metadata:
   name: socios-tenis-service
   namespace: socios-tenis
+  labels:
+    app: socios-tenis
 spec:
   type: NodePort   # <--- así podés acceder desde el navegador con minikube service
   selector:
     app: socios-tenis
   ports:
     - protocol: TCP
+      name: http
       port: 8000
       targetPort: 8000
       nodePort: 30080   # lo fijamos para que siempre sea http://localhost:30080

--- a/k8s/servicemonitor.yaml
+++ b/k8s/servicemonitor.yaml
@@ -14,4 +14,5 @@ spec:
       - socios-tenis
   endpoints:
     - port: http
+      path: /metrics
       interval: 15s

--- a/run.sh
+++ b/run.sh
@@ -20,6 +20,20 @@ case $1 in
     kubectl apply -f k8s/namespace.yaml
     kubectl apply -f k8s/deployment.yaml
     kubectl apply -f k8s/service.yaml
+    kubectl apply -f k8s/servicemonitor.yaml
+    ;;
+
+  monitoring-up)
+    echo "📈 Instalando kube-prometheus-stack (Prometheus + Grafana)..."
+    helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+    helm repo update
+    helm upgrade --install kube-prometheus-stack prometheus-community/kube-prometheus-stack \
+      --namespace monitoring --create-namespace
+    ;;
+
+  monitoring-down)
+    echo "🧹 Eliminando kube-prometheus-stack..."
+    helm uninstall kube-prometheus-stack -n monitoring || true
     ;;
 
   urls)
@@ -31,11 +45,12 @@ case $1 in
     echo "🛑 Apagando todo..."
     kubectl delete -f k8s/service.yaml || true
     kubectl delete -f k8s/deployment.yaml || true
+    kubectl delete -f k8s/servicemonitor.yaml || true
     kubectl delete -f k8s/namespace.yaml || true
     minikube stop
     ;;
-    
+
   *)
-    echo "Uso: ./run.sh {build-push|mk-up|mk-deploy|urls|down}"
+    echo "Uso: ./run.sh {build-push|mk-up|mk-deploy|monitoring-up|monitoring-down|urls|down}"
     ;;
 esac


### PR DESCRIPTION
## Summary
- add a README that documents how to run the app in Minikube and enable Prometheus/Grafana via kube-prometheus-stack
- align the Service manifest and ServiceMonitor so Prometheus can discover the FastAPI metrics endpoint
- extend the helper script with commands to install/uninstall kube-prometheus-stack and manage the ServiceMonitor lifecycle

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc52fb1194832c9ce0b619b4da83fb