### PR TITLE
Add single-command bootstrap workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ Este proyecto contiene una API en FastAPI que expone métricas Prometheus median
      ```bash
      kubectl port-forward svc/kube-prometheus-stack-grafana -n monitoring 3000:80
      ```
-     Luego abre http://localhost:3000 (usuario `admin`, contraseña obtenida con `kubectl get secret kube-prometheus-stack-grafana -n monitoring -o jsonpath="{.data.admin-password}" | base64 --decode`).
+     Mantén el comando anterior en ejecución (abre un túnel desde tu máquina hacia el `Service` dentro del clúster) y luego abre http://localhost:3000. El usuario por defecto es `admin` y la contraseña puedes obtenerla con:
+     ```bash
+     kubectl get secret kube-prometheus-stack-grafana -n monitoring -o jsonpath="{.data.admin-password}" | base64 --decode
+     ```
+     > ℹ️ Si no puedes acceder a Grafana en el puerto 3000, asegúrate de estar en otra terminal con el `port-forward` en ejecución y verifica que el Pod esté listo con `kubectl get pods -n monitoring -l app.kubernetes.io/name=grafana`.
 
    - Prometheus:
      ```bash

--- a/k8s/servicemonitor.yaml
+++ b/k8s/servicemonitor.yaml
@@ -4,7 +4,7 @@ metadata:
   name: socios-tenis-monitor
   namespace: socios-tenis   # 👈 Ahora en el mismo namespace que tu app
   labels:
-    release: kube-prometheus
+    release: kube-prometheus-stack
 spec:
   selector:
     matchLabels:

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,19 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-case $1 in
+print_section() {
+  echo
+  echo "==================== $1 ===================="
+}
+
+ensure_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "❌ No se encontró el comando '$1'. Por favor instalalo antes de continuar." >&2
+    exit 1
+  fi
+}
+
+case ${1:-} in
   build-push)
     echo "🚀 Construyendo y subiendo imagen a DockerHub..."
     cd backend
@@ -50,7 +62,95 @@ case $1 in
     minikube stop
     ;;
 
+  all-in-one)
+    echo "🚀 Despliegue completo (aplicación + monitoreo + port-forwards)"
+
+    ensure_command docker
+    ensure_command minikube
+    ensure_command kubectl
+    ensure_command helm
+
+    IMAGE_NAME="${IMAGE_NAME:-tomas1aws/socios-tenis-id:latest}"
+
+    print_section "Construyendo imagen Docker"
+    (cd backend && docker build -t "$IMAGE_NAME" .)
+
+    print_section "Iniciando Minikube"
+    if ! minikube status >/dev/null 2>&1; then
+      minikube start --driver=docker
+    else
+      echo "✅ Minikube ya está en ejecución"
+    fi
+
+    print_section "Sincronizando imagen con Minikube"
+    minikube image load "$IMAGE_NAME"
+
+    print_section "Aplicando manifests de Kubernetes"
+    kubectl apply -f k8s/namespace.yaml
+    kubectl apply -f k8s/deployment.yaml
+    kubectl apply -f k8s/service.yaml
+    kubectl apply -f k8s/servicemonitor.yaml
+
+    print_section "Instalando/actualizando kube-prometheus-stack"
+    if ! helm repo list | grep -q '^prometheus-community'; then
+      helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+    fi
+    helm repo update
+    helm upgrade --install kube-prometheus-stack prometheus-community/kube-prometheus-stack \
+      --namespace monitoring --create-namespace
+
+    print_section "Esperando a que los recursos estén listos"
+    kubectl -n socios-tenis wait --for=condition=available deployment/socios-tenis-deployment --timeout=240s
+    kubectl -n monitoring wait --for=condition=ready pod -l app.kubernetes.io/name=grafana --timeout=300s
+    kubectl -n monitoring wait --for=condition=ready pod -l app.kubernetes.io/name=prometheus --timeout=300s
+
+    print_section "Recuperando credenciales de Grafana"
+    GRAFANA_PASSWORD=$(kubectl get secret kube-prometheus-stack-grafana -n monitoring -o jsonpath='{.data.admin-password}' | base64 --decode)
+    echo "🔐 Usuario: admin"
+    echo "🔐 Contraseña: $GRAFANA_PASSWORD"
+
+    print_section "Iniciando port-forwards"
+    API_LOG=$(mktemp)
+    PROM_LOG=$(mktemp)
+    GRAFANA_LOG=$(mktemp)
+
+    kubectl -n socios-tenis port-forward svc/socios-tenis-service 8000:8000 >"$API_LOG" 2>&1 &
+    API_PID=$!
+    kubectl -n monitoring port-forward svc/kube-prometheus-stack-prometheus 9090:9090 >"$PROM_LOG" 2>&1 &
+    PROM_PID=$!
+    kubectl -n monitoring port-forward svc/kube-prometheus-stack-grafana 3000:80 >"$GRAFANA_LOG" 2>&1 &
+    GRAFANA_PID=$!
+
+    cleanup() {
+      echo
+      echo "🛑 Deteniendo port-forwards..."
+      kill "$API_PID" "$PROM_PID" "$GRAFANA_PID" 2>/dev/null || true
+    }
+    trap cleanup EXIT
+
+    sleep 3
+    if ! kill -0 "$API_PID" >/dev/null 2>&1; then
+      echo "⚠️ El port-forward de la API falló. Revisá el log en $API_LOG" >&2
+    fi
+    if ! kill -0 "$PROM_PID" >/dev/null 2>&1; then
+      echo "⚠️ El port-forward de Prometheus falló. Revisá el log en $PROM_LOG" >&2
+    fi
+    if ! kill -0 "$GRAFANA_PID" >/dev/null 2>&1; then
+      echo "⚠️ El port-forward de Grafana falló. Revisá el log en $GRAFANA_LOG" >&2
+    fi
+
+    echo
+    echo "✅ Todo listo. Endpoints disponibles en tu máquina local:"
+    echo "  • API:         http://localhost:8000"
+    echo "  • Prometheus:  http://localhost:9090"
+    echo "  • Grafana:     http://localhost:3000"
+    echo
+    echo "Presioná Ctrl+C cuando quieras cerrar los port-forwards y salir."
+
+    wait
+    ;;
+
   *)
-    echo "Uso: ./run.sh {build-push|mk-up|mk-deploy|monitoring-up|monitoring-down|urls|down}"
+    echo "Uso: ./run.sh {build-push|mk-up|mk-deploy|monitoring-up|monitoring-down|urls|down|all-in-one}"
     ;;
 esac


### PR DESCRIPTION
## Summary
- add helper functions to `run.sh` and extend usage handling
- implement an `all-in-one` command that builds the image, deploys the stack, waits for readiness, and starts port-forwards
- automatically print Grafana admin credentials and exposed endpoints for quick access

## Testing
- not run (requires local Kubernetes toolchain)


------
https://chatgpt.com/codex/tasks/task_e_68dc593b9620832cae2211dadced61e4